### PR TITLE
Update Model.class.php

### DIFF
--- a/Mvc/Model.class.php
+++ b/Mvc/Model.class.php
@@ -471,8 +471,11 @@ abstract class Model
 		}	
         
         self::$result = $conn->select();
-        self::$conn = null;
-
+        //self::$conn = null;
+	if(!$conn->inTransaction()) {
+            self::$conn = null;
+        }
+        
         return self::$result;
     }
 }


### PR DESCRIPTION
Não permitia fazer transações quando tinha mais de uma Model instanciada porque ele limpava a $conn.
